### PR TITLE
expose authentication challenge callback to support iOS WKWebView

### DIFF
--- a/src/ios/ClientCertificate.h
+++ b/src/ios/ClientCertificate.h
@@ -28,6 +28,8 @@
 - (void)registerAuthenticationCertificate:(CDVInvokedUrlCommand*)command;
 - (void)validateSslChain:(CDVInvokedUrlCommand*)command;
 
++ (void) didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler withOptionsNullable:(NSObject *) options;
+
 + (void)registerCertificateFromPath:(NSString*)path withPassword:(NSString*)password;
 
 @end

--- a/src/ios/ClientCertificate.m
+++ b/src/ios/ClientCertificate.m
@@ -124,13 +124,15 @@ static ClientCertificate * mydelegate = NULL;
 
 - (void) didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler
 {
-    // works with this proposal:
-    // https://github.com/apache/cordova-ios/pull/1212
+    // works with cordova-ios & WKWebView with update proposed in:
+    // - https://github.com/apache/cordova-ios/pull/1212
+    // - https://github.com/brodybits/cordova-ios/tree/auth-challenge-callback-support
     [ClientCertificate didReceiveAuthenticationChallenge:challenge completionHandler:completionHandler withOptionsNullable:nil];
 }
 
 + (void) didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler withOptionsNullable:(NSObject *) _optionsIgnored
 {
+    // now exposed as a static method usable by @brodybits/cordova-plugin-ios-xhr
     if([challenge previousFailureCount] == 0) {
 
         NSURLCredential *credential = nil;

--- a/src/ios/ClientCertificate.m
+++ b/src/ios/ClientCertificate.m
@@ -116,6 +116,18 @@ static ClientCertificate * mydelegate = NULL;
 
 - (void)customHTTPProtocol:(CustomHTTPProtocol *)protocol didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
+    // ---
+    NSLog(@"XXX TODO XXX XXX");
+}
+
+- (void) didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler
+{
+    // ---
+    NSLog(@"^^^^ client cert auth plugin did receive auth challenge");
+
+//    // XXX TBD XXX
+//    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+
     if([challenge previousFailureCount] == 0) {
 
         NSURLCredential *credential = nil;
@@ -160,8 +172,11 @@ static ClientCertificate * mydelegate = NULL;
 
         }
 
-        [protocol resolveAuthenticationChallenge:challenge withCredential:credential];
+        // [protocol resolveAuthenticationChallenge:challenge withCredential:credential];
 
+        // ---
+        NSLog(@"using credential to resolve auth challenge");
+        completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
     }
 }
 

--- a/src/ios/ClientCertificate.m
+++ b/src/ios/ClientCertificate.m
@@ -116,14 +116,21 @@ static ClientCertificate * mydelegate = NULL;
 
 - (void)customHTTPProtocol:(CustomHTTPProtocol *)protocol didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
-    // ---
-    [self didReceiveAuthenticationChallenge:challenge completionHandler:^(NSURLSessionAuthChallengeDisposition _, NSURLCredential * credential){
+    // support cordova-ios pre-6.x with UIWebView
+    [ClientCertificate didReceiveAuthenticationChallenge:challenge completionHandler:^(NSURLSessionAuthChallengeDisposition _, NSURLCredential * credential){
         // ---
         [protocol resolveAuthenticationChallenge:challenge withCredential:credential];
-    }];
+    } withOptionsNullable:nil];
 }
 
 - (void) didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler
+{
+    // works with this proposal:
+    // https://github.com/apache/cordova-ios/pull/1212
+    [ClientCertificate didReceiveAuthenticationChallenge:challenge completionHandler:completionHandler withOptionsNullable:nil];
+}
+
++ (void) didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler withOptionsNullable:(NSObject *) _optionsIgnored
 {
     // ---
     NSLog(@"^^^^ client cert auth plugin did receive auth challenge");

--- a/src/ios/ClientCertificate.m
+++ b/src/ios/ClientCertificate.m
@@ -117,7 +117,10 @@ static ClientCertificate * mydelegate = NULL;
 - (void)customHTTPProtocol:(CustomHTTPProtocol *)protocol didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
     // ---
-    NSLog(@"XXX TODO XXX XXX");
+    [self didReceiveAuthenticationChallenge:challenge completionHandler:^(NSURLSessionAuthChallengeDisposition _, NSURLCredential * credential){
+        // ---
+        [protocol resolveAuthenticationChallenge:challenge withCredential:credential];
+    }];
 }
 
 - (void) didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler

--- a/src/ios/ClientCertificate.m
+++ b/src/ios/ClientCertificate.m
@@ -118,7 +118,6 @@ static ClientCertificate * mydelegate = NULL;
 {
     // support cordova-ios pre-6.x with UIWebView
     [ClientCertificate didReceiveAuthenticationChallenge:challenge completionHandler:^(NSURLSessionAuthChallengeDisposition _, NSURLCredential * credential){
-        // ---
         [protocol resolveAuthenticationChallenge:challenge withCredential:credential];
     } withOptionsNullable:nil];
 }
@@ -132,12 +131,6 @@ static ClientCertificate * mydelegate = NULL;
 
 + (void) didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler withOptionsNullable:(NSObject *) _optionsIgnored
 {
-    // ---
-    NSLog(@"^^^^ client cert auth plugin did receive auth challenge");
-
-//    // XXX TBD XXX
-//    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
-
     if([challenge previousFailureCount] == 0) {
 
         NSURLCredential *credential = nil;
@@ -182,10 +175,6 @@ static ClientCertificate * mydelegate = NULL;
 
         }
 
-        // [protocol resolveAuthenticationChallenge:challenge withCredential:credential];
-
-        // ---
-        NSLog(@"using credential to resolve auth challenge");
         completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
     }
 }


### PR DESCRIPTION
expose "didReceiveAuthenticationChallenge:completionHandler:completionHandler:" callback
from ClientCertificate plugin object to support iOS WKWebView

resolves #7

requires support from cordova-ios as I proposed in:

- https://github.com/apache/cordova-ios/pull/1212

IMPORTANT NOTES:

- requires CORS support to be enabled in both the Cordova app and on the server
- ~~breaks UIWebView support from cordova-ios pre-6.x (see TODO item below)~~

TODO:

- [x] cleanup logging
- [x] cleanup some comments
- [x] ~~find a way to do this without breaking UIWebView support (cordova-ios pre-6.x)~~
- [ ] describe this solution in a comment in issue #7
- [ ] update documentation